### PR TITLE
Use formatter.json inside .vscode folder resolves #3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 test
 _test
 *.vsix
+tslint.json


### PR DESCRIPTION
This code allows users to add formatter.json file in .vscode folder instead of using config file located in extension folder.

This is my first work on a vs-code extension, so not sure if I did things correctly.

Happy to amend, update if needed.
