### PR TITLE
:sparkles: feature: disable the formatter for a specific language

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,6 +69,11 @@ function beatify(documentContent: String, languageId) {
         }
     }
 
+    if (beutifyOptions === false) {
+        // console.log('Formatting disabled for ' + languageId);
+        return;
+    }
+
     return beatiFunc(documentContent, beutifyOptions);
 }
 


### PR DESCRIPTION
Hi guys, 

I've been using your extension, which is very good. But for HTML I don't want to use any formatter so I tried to disable it on your extension and I figured out there is no way to do that. That's why I created this PR. Please accept it if you think is suited to your thinking in terms of what the extension needs. To disable the formatter for a specific language is pretty simple.. just edit the global or local file for and set the languageId attribute to `false`. 

For example, to disable `html` formatter just do this:

```
{
  "onSave": true,
  "javascript": {
    "indent_size": 2,
    "indent_char": " ",
    "eol": "auto",
    "preserve_newlines": true,
    "break_chained_methods": false,
    "max_preserve_newlines": 0,
    "space_in_paren": false,
    "space_in_empty_paren": false,
    "jslint_happy": false,
    "space_after_anon_function": false,
    "keep_array_indentation": false,
    "space_before_conditional": true,
    "unescape_strings": false,
    "wrap_line_length": 0,
    "e4x": false,
    "end_with_newline": false,
    "comma_first": false,
    "brace_style": "collapse-preserve-inline"
  },
  "css": {
    "indent_size": 2,
    "indentCharacter": " ",
    "indent_char": " ",
    "selector_separator_newline": true,
    "end_with_newline": false,
    "newline_between_rules": true,
    "eol": "\n"
  },
  "html": false // this disables the html formatter
}
```