### PR TITLE
Use TextDocumentWillSaveEvent to make changes to files being saved

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,20 +37,16 @@
         "onCommand:Lonefy.formatterCreateLocalConfig"
     ],
     "contributes": {
-        "commands": [
-            {
-                "command": "Lonefy.formatting",
-                "title": "Formatter"
-            },
-            {
-                "command": "Lonefy.formatterConfig",
-                "title": "Formatter Config"
-            },
-            {
-                "command": "Lonefy.formatterCreateLocalConfig",
-                "title": "Formatter Create Local Config"
-            }
-        ]
+        "commands": [{
+            "command": "Lonefy.formatting",
+            "title": "Formatter"
+        }, {
+            "command": "Lonefy.formatterConfig",
+            "title": "Formatter Config"
+        }, {
+            "command": "Lonefy.formatterCreateLocalConfig",
+            "title": "Formatter Create Local Config"
+        }]
     },
     "main": "./out/src/extension",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "url": "https://github.com/lonefy/vscode-js-css-html-formatter"
     },
     "engines": {
-        "vscode": "^1.0.0"
+        "vscode": "^1.6.0"
     },
     "activationEvents": [
         "onLanguage:json",
@@ -37,16 +37,20 @@
         "onCommand:Lonefy.formatterCreateLocalConfig"
     ],
     "contributes": {
-        "commands": [{
-            "command": "Lonefy.formatting",
-            "title": "Formatter"
-        }, {
-            "command": "Lonefy.formatterConfig",
-            "title": "Formatter Config"
-        }, {
-            "command": "Lonefy.formatterCreateLocalConfig",
-            "title": "Formatter Create Local Config"
-        }]
+        "commands": [
+            {
+                "command": "Lonefy.formatting",
+                "title": "Formatter"
+            },
+            {
+                "command": "Lonefy.formatterConfig",
+                "title": "Formatter Config"
+            },
+            {
+                "command": "Lonefy.formatterCreateLocalConfig",
+                "title": "Formatter Create Local Config"
+            }
+        ]
     },
     "main": "./out/src/extension",
     "scripts": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -115,7 +115,7 @@ export function activate(context: vscode.ExtensionContext) {
     }));
 
     context.subscriptions.push(vscode.workspace.onWillSaveTextDocument(e => {
-        formatter.onSave(e.document)
+        formatter.onSave(e)
     }));
 
 
@@ -232,8 +232,8 @@ class Formatter {
         });
     }
 
-    public onSave(document) {
-
+    public onSave(e: vscode.TextDocumentWillSaveEvent) {
+        var { document } = e;
         var docType: Array<string> = ['css', 'scss', 'javascript', 'html', 'json']
         var global = path.join(__dirname, 'formatter.json');
         var local = path.join(getRootPath(), '.vscode', 'formatter.json');
@@ -256,11 +256,6 @@ class Formatter {
             return;
         }
 
-        // Get the current text editor
-        let activeEditor = vscode.window.activeTextEditor;
-        if (!activeEditor) {
-            return;
-        }
 
         var start = new vscode.Position(0, 0);
         var end = new vscode.Position(document.lineCount - 1, document.lineAt(document.lineCount - 1).text.length);
@@ -273,17 +268,13 @@ class Formatter {
         var formatted = beatify(content, document.languageId);
 
         if (formatted) {
-            return activeEditor.edit(function (editor) {
-                console.log(editor.replace)
-                var start = new vscode.Position(0, 0);
-                var end = new vscode.Position(document.lineCount - 1, document.lineAt(document.lineCount - 1).text.length);
-                range = new vscode.Range(start, end);
-                document.save();
-                activeEditor = null
-                return editor.replace(range, formatted);
-            });
+            var start = new vscode.Position(0, 0);
+            var end = new vscode.Position(document.lineCount - 1, document.lineAt(document.lineCount - 1).text.length);
+            range = new vscode.Range(start, end);
+            document.save();
+            var edit = vscode.TextEdit.replace(range, formatted);
+            e.waitUntil(Promise.resolve([edit]));
         }
-
 
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -271,7 +271,6 @@ class Formatter {
             var start = new vscode.Position(0, 0);
             var end = new vscode.Position(document.lineCount - 1, document.lineAt(document.lineCount - 1).text.length);
             range = new vscode.Range(start, end);
-            document.save();
             var edit = vscode.TextEdit.replace(range, formatted);
             e.waitUntil(Promise.resolve([edit]));
         }


### PR DESCRIPTION
This PR fixes https://github.com/Lonefy/vscode-JS-CSS-HTML-formatter/issues/53 by not applying formatting edits with the active editor but via the on-will-save API. This is required because documents that are not open or not open in the active editor can be saved and get scrambled with the existing logic.