### PR TITLE
There is absolutely no justification for formatting on save by default

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -245,7 +245,7 @@ class Formatter {
             try {
                 onSave = require(global).onSave;
             } catch (error) {
-                onSave = true;
+                onSave = false;
             }
         }
 


### PR DESCRIPTION
So set onSave to false if not explicitely set to true in settings.